### PR TITLE
Default push to not drop database

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ expected to work with Node 0.x or io.js.
 Dookie can be used either via `require('dookie');` in Node.js, or from the
 command line as an executable. Dookie's fundamental operations are:
 
-1. Push - clear out a database and insert some data
+1. Push - optionally clear out a database and insert some data
 2. Pull - write the contents of a database to a file
 
 Push is more interesting, so let's start with that. You can access the

--- a/bin/dookie.js
+++ b/bin/dookie.js
@@ -14,6 +14,7 @@ commander.
   option('-f, --file <file>', 'File to read/write from').
   option('-d, --db <database>', 'Database to read/write from').
   option('-u, --uri <uri>', 'MongoDB URI to use (mongodb://localhost:27017 by default)').
+  option('--dropDatabase', 'Drop database when pushing').
   parse(process.argv);
 
 const cmd = process.argv[2];
@@ -67,8 +68,9 @@ if (cmd === 'pull') {
     } else {
       data = yaml.safeLoad(fs.readFileSync(commander.file));
     }
+
     yield dookie.push(uri, data,
-      commander.file);
+      { filename: commander.file, dropDatabase: commander.dropDatabase });
 
     console.log('Success!');
     process.exit(0);

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function push(uri, data, options) {
     const db = yield mongodb.MongoClient.connect(uri);
     options = standardizePushOptions(options);
 
-    if (options.dropDatabase !== false) {
+    if (options.dropDatabase === true) {
       yield db.dropDatabase();
     }
 
@@ -178,8 +178,8 @@ function pullToStream(uri, stream) {
   });
 }
 
-exports.push = function(uri, data, path) {
-  return push(uri, data, path);
+exports.push = function(uri, data, pathOrOptions) {
+  return push(uri, data, pathOrOptions);
 };
 
 exports.pull = function(uri) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dot-component": "0.1.1",
     "js-yaml": "3.2.1",
     "mongodb": "~2.2.0",
-    "mongodb-extended-json": "1.6.3",
+    "mongodb-extended-json": "1.7.0",
     "mongodb-ns": "1.0.3",
     "thunkify": "2.1.2"
   },

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -34,6 +34,9 @@ describe('Examples', function() {
       const parsed = yaml.safeLoad(contents);
 
       const mongodbUri = 'mongodb://localhost:27017/test';
+      const db = yield mongodb.MongoClient.connect(mongodbUri);
+      yield db.dropDatabase();
+
       // Insert data into dookie
       // Or, at the command line:
       // `dookie push --db test --file ./example/basic/file.yml`
@@ -41,7 +44,6 @@ describe('Examples', function() {
 
       // ------------------------
       // Now that you've pushed, you should see the data in MongoDB
-      const db = yield mongodb.MongoClient.connect(mongodbUri);
       const collections = (yield db.listCollections().toArray()).
         map(v => v.name).filter(v => !v.startsWith('system.')).sort();
       assert.equal(collections.length, 2);
@@ -94,6 +96,9 @@ describe('Examples', function() {
       const parsed = yaml.safeLoad(contents);
 
       const mongodbUri = 'mongodb://localhost:27017/test';
+      const db = yield mongodb.MongoClient.connect(mongodbUri);
+      yield db.dropDatabase();
+
       // Insert data into dookie
       // Or, at the command line:
       // `dookie push --db test --file ./example/basic/parent.yml`
@@ -101,8 +106,6 @@ describe('Examples', function() {
 
       // ------------------------
       // Now that you've pushed, you should see the data in MongoDB
-      const db = yield mongodb.MongoClient.connect(mongodbUri);
-
       const people = yield db.collection('people').find().toArray();
       assert.deepEqual(people, [{ _id: 'Axl Rose' }]);
 
@@ -139,6 +142,9 @@ describe('Examples', function() {
       const parsed = yaml.safeLoad(contents);
 
       const mongodbUri = 'mongodb://localhost:27017/test';
+      const db = yield mongodb.MongoClient.connect(mongodbUri);
+      yield db.dropDatabase();
+
       // Insert data into dookie
       // Or, at the command line:
       // `dookie push --db test --file ./example/$extend.yml`
@@ -146,8 +152,6 @@ describe('Examples', function() {
 
       // ------------------------
       // Now that you've pushed, you should see the data in MongoDB
-      const db = yield mongodb.MongoClient.connect(mongodbUri);
-
       const people = yield db.collection('people').find().toArray();
       assert.deepEqual(people, [
         { band: `Guns N' Roses`, _id: 'Axl Rose' },
@@ -180,6 +184,9 @@ describe('Examples', function() {
       const parsed = yaml.safeLoad(contents);
 
       const mongodbUri = 'mongodb://localhost:27017/test';
+      const db = yield mongodb.MongoClient.connect(mongodbUri);
+      yield db.dropDatabase();
+
       // Insert data into dookie
       // Or, at the command line:
       // `dookie push --db test --file ./example/$eval.yml`
@@ -187,8 +194,6 @@ describe('Examples', function() {
 
       // ------------------------
       // Now that you've pushed, you should see the data in MongoDB
-      const db = yield mongodb.MongoClient.connect(mongodbUri);
-
       const people = yield db.collection('people').find().toArray();
       assert.deepEqual(people, [
         { _id: 0, firstName: 'Axl', lastName: 'Rose', name: 'Axl Rose' }
@@ -214,8 +219,23 @@ describe('Examples', function() {
 
   it('can pull() data out of MongoDB', function(done) {
     co(function*() {
+      // acquit:ignore:start
+      const fs = require('fs');
+      const yaml = require('js-yaml');
+      // acquit:ignore:end
+      const filename = './example/$eval.yml';
+      const contents = fs.readFileSync(filename);
+      const parsed = yaml.safeLoad(contents);
+
+
       const mongodbUri = 'mongodb://localhost:27017/test';
+      const db = yield mongodb.MongoClient.connect(mongodbUri);
+      yield db.dropDatabase();
+
       // Insert data into dookie
+      yield dookie.push(mongodbUri, parsed, filename);
+
+      // Pull data with dookie
       // Or, at the command line:
       // `dookie pull --db test --file ./output.json`
       const json = yield dookie.pull(mongodbUri);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,7 +13,7 @@ describe('dookie:push', function() {
   it('inserts documents', function(done) {
     co(function*() {
       const uri = 'mongodb://localhost:27017/test';
-      yield dookie.push(uri, { 'sample': [{ x: 1 }] });
+      yield dookie.push(uri, { 'sample': [{ x: 1 }] }, { dropDatabase: true });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const docs = yield db.collection('sample').find({}).toArray();
@@ -35,7 +35,7 @@ describe('dookie:push', function() {
         ]
       };
 
-      yield dookie.push(uri, toInsert);
+      yield dookie.push(uri, toInsert, { dropDatabase: true });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const docs = yield db.collection('sample').find({}).toArray();
@@ -60,7 +60,7 @@ describe('dookie:push', function() {
         ]
       };
 
-      yield dookie.push(uri, toInsert);
+      yield dookie.push(uri, toInsert, { dropDatabase: true });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const docs = yield db.collection('sample').find({}).toArray();
@@ -79,7 +79,7 @@ describe('dookie:push', function() {
       const path = './example/$require/parent.yml';
       const toInsert = yaml.safeLoad(fs.readFileSync(path));
 
-      yield dookie.push(uri, toInsert, path);
+      yield dookie.push(uri, toInsert, path, { dropDatabase: true });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const people = yield db.collection('people').find({}).toArray();
@@ -104,7 +104,7 @@ describe('dookie:push', function() {
         ]
       };
 
-      yield dookie.push(uri, toInsert);
+      yield dookie.push(uri, toInsert, { dropDatabase: true });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const docs = yield db.collection('sample').find({}).toArray();
@@ -126,8 +126,8 @@ describe('dookie:push', function() {
         ]
       };
 
+      yield dookie.push(uri, _.cloneDeep(toInsert), { dropDatabase: true });
       yield dookie.push(uri, _.cloneDeep(toInsert));
-      yield dookie.push(uri, _.cloneDeep(toInsert), { dropDatabase: false });
 
       const db = yield mongodb.MongoClient.connect(uri);
       const docs = yield db.collection('sample').find({}).toArray();


### PR DESCRIPTION
Defaulting to dropping the database on push seems dangerous, especially since the CLI doesn't allow a user to tell it not to drop.

So added a new flag `--dropDatabase` to the CLI, and defaulted the dropDatabase behavior to false.

Also fix the failing test from the mongo update.